### PR TITLE
feat: Add query parms to whats-new get request

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -7,7 +7,7 @@ module.exports = function buildApi(router) {
 			title: 'Stay productive | Welcome!',
 			copyright: new Date().getFullYear(),
 		};
-	
+
 		res.render('hi', ctx, (err, html) => {
 			if (err) {
 				return next(err);
@@ -15,7 +15,7 @@ module.exports = function buildApi(router) {
 			res.send(html);
 		});
 	});
-	
+
 	router.get('/see-you-later', (req, res, next) => {
 		res.render('bye', {
 			message: 'We will miss you. Come back sooner.',
@@ -28,11 +28,37 @@ module.exports = function buildApi(router) {
 			res.send(html);
 		});
 	});
-	
-	router.get('/whats-new', (req, res) => {
-		res.send('Whats up!');
+
+	router.get('/whats-new/:from/:to', (req, res) => {
+		//Function to check if string is numeric (should cover undefined, "", " ", null, true, false cases)
+		const isNumeric = (input) => {
+			return (input - 0) == input && ('' + input).trim().length > 0;
+		}
+
+		//Function to check if given query param is valid (both parts are numeric strings and number after decimal point is single digit numeric string)
+		const isValid = (string) => {
+			const fp = string.split('.')[0];
+			const sp = string.split('.')[1];
+
+			if (isNumeric(fp) && isNumeric(sp) && sp.length === 1)
+				return true;
+			return false;
+		}
+
+		//Access query params
+		const from = req.params.from;
+		const to = req.params.to;
+
+		if (isValid(from) && isValid(to)) {
+			res.status(200).send(`Whats new from ${from} to ${to}`);
+		}
+		else {
+			// TODO: If format isnt matching - change below
+			res.status(400).send("Format didn't match");
+		}
+
 	});
-	
+
 	router.all('*', (req, res) => {
 		// TODO: send 4xx page
 		res.status(404).send('I do not understand you');

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const isValid = require('./isValid');
+
 module.exports = function buildApi(router) {
 	router.get('/getting-started', (req, res, next) => {
 		const ctx = {
@@ -29,34 +31,18 @@ module.exports = function buildApi(router) {
 		});
 	});
 
-	router.get('/whats-new/:from/:to', (req, res) => {
-		//Function to check if string is numeric (should cover undefined, "", " ", null, true, false cases)
-		const isNumeric = (input) => {
-			return (input - 0) == input && ('' + input).trim().length > 0;
-		}
-
-		//Function to check if given query param is valid (both parts are numeric strings and number after decimal point is single digit numeric string)
-		const isValid = (string) => {
-			const fp = string.split('.')[0];
-			const sp = string.split('.')[1];
-
-			if (isNumeric(fp) && isNumeric(sp) && sp.length === 1)
-				return true;
-			return false;
-		}
-
-		//Access query params
-		const from = req.params.from;
-		const to = req.params.to;
+	router.get('/whats-new', (req, res) => {
+		//Access query string
+		const from = req.query.from;
+		const to = req.query.to;
 
 		if (isValid(from) && isValid(to)) {
 			res.status(200).send(`Whats new from ${from} to ${to}`);
 		}
 		else {
 			// TODO: If format isnt matching - change below
-			res.status(400).send("Format didn't match");
+			res.status(200).send("Render whats-new general page");
 		}
-
 	});
 
 	router.all('*', (req, res) => {

--- a/lib/isValid.js
+++ b/lib/isValid.js
@@ -12,7 +12,8 @@ module.exports = function isValid(string) {
         if (isNumeric(fp) && isNumeric(sp) && sp.length === 1)
             return true;
         return false;
-    } catch (error) {
+    }
+    catch (error) {
         return false;
     }
 }

--- a/lib/isValid.js
+++ b/lib/isValid.js
@@ -1,19 +1,20 @@
 //Function to check if string is numeric (should cover undefined, "", " ", null, true, false cases)
 function isNumeric(input) {
-    return (input - 0) == input && ('' + input).trim().length > 0;
+	return (input - 0) == input && ('' + input).trim().length > 0;
 }
 
 //Function to check if given query param is valid (both parts are numeric strings and number after decimal point is single digit numeric string)
+//Also returns false if split function fails as of now
 module.exports = function isValid(string) {
-    try {
-        const fp = string.split('.')[0];
-        const sp = string.split('.')[1];
+	try {
+		const fp = string.split('.')[0];
+		const sp = string.split('.')[1];
 
-        if (isNumeric(fp) && isNumeric(sp) && sp.length === 1)
-            return true;
-        return false;
-    }
-    catch (error) {
-        return false;
-    }
+		if (isNumeric(fp) && isNumeric(sp) && sp.length === 1)
+			return true;
+		return false;
+	}
+	catch (error) {
+		return false;
+	}
 }

--- a/lib/isValid.js
+++ b/lib/isValid.js
@@ -1,0 +1,18 @@
+//Function to check if string is numeric (should cover undefined, "", " ", null, true, false cases)
+function isNumeric(input) {
+    return (input - 0) == input && ('' + input).trim().length > 0;
+}
+
+//Function to check if given query param is valid (both parts are numeric strings and number after decimal point is single digit numeric string)
+module.exports = function isValid(string) {
+    try {
+        const fp = string.split('.')[0];
+        const sp = string.split('.')[1];
+
+        if (isNumeric(fp) && isNumeric(sp) && sp.length === 1)
+            return true;
+        return false;
+    } catch (error) {
+        return false;
+    }
+}


### PR DESCRIPTION
## Closes: #3 
- Added query parameters to whats-new request
- Sent them to client 
- Validated input for type x.x (something like 1.54 will fail)

## Screenshots
Correct request 
![image](https://user-images.githubusercontent.com/71214045/135819928-55a635fa-0dd4-438c-8dc3-0e341406fc4b.png)

Incorrect request
![image](https://user-images.githubusercontent.com/71214045/135819972-43998746-2a5d-41d1-985a-4b0b6a8687b7.png)

## Further questions

- Current request format http://localhost:3080/whats-new/x.x/x.x 
Do you want me to change this to http://localhost:3080/whats-new/from/1.4/to/2.50

- Should I create views for this? 

- Currently it is just accepting single digits before and after decimal ( 1.5 )
Should the request allow multiple digits after decimal. eg - something like 1.544 or 1.54? 

TIA 😄 
